### PR TITLE
Rewrite in Go

### DIFF
--- a/cmd/emu2mqtt/main.go
+++ b/cmd/emu2mqtt/main.go
@@ -41,12 +41,17 @@ func main() {
 	reader := serial.NewReader(cfg, metrics, logger)
 	go reader.Run(ctx)
 
+	deviceIDSet := false
 	for {
 		select {
 		case <-ctx.Done():
 			logger.Info("shutting down")
 			return
 		case m := <-metrics:
+			if !deviceIDSet && m.DeviceMacID != "" {
+				publisher.UpdateDeviceID(m.DeviceMacID)
+				deviceIDSet = true
+			}
 			logger.Info("metric received", "sensor", m.SensorName, "value", m.Value)
 			if err := publisher.PublishState(m.SensorName, m.Value); err != nil {
 				logger.Warn("publish state error", "err", err)

--- a/pkg/mqtt/mqtt.go
+++ b/pkg/mqtt/mqtt.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/danlindow/emu2mqtt/pkg/config"
@@ -52,14 +54,43 @@ var sensors = []sensorDef{
 
 // Publisher manages the MQTT connection and publishes HA discovery and state messages.
 type Publisher struct {
-	cfg    *config.Config
-	client paho.Client
-	logger *slog.Logger
+	cfg      *config.Config
+	client   paho.Client
+	logger   *slog.Logger
+	mu       sync.Mutex
+	deviceID string // set from DeviceMacId once first metric arrives
 }
 
 // NewPublisher creates a Publisher. Call Connect before publishing.
 func NewPublisher(cfg *config.Config, logger *slog.Logger) *Publisher {
 	return &Publisher{cfg: cfg, logger: logger}
+}
+
+// UpdateDeviceID sets the HA device identifier from the EMU-2 MAC address and
+// republishes discovery so Home Assistant updates its device registry.
+// Safe to call from any goroutine; no-ops if the MAC hasn't changed.
+func (p *Publisher) UpdateDeviceID(rawMAC string) {
+	mac := strings.TrimPrefix(strings.TrimPrefix(rawMAC, "0x"), "0X")
+	p.mu.Lock()
+	if p.deviceID == mac {
+		p.mu.Unlock()
+		return
+	}
+	p.deviceID = mac
+	p.mu.Unlock()
+	p.logger.Info("device MAC identified, republishing discovery", "mac", mac)
+	if err := p.PublishDiscovery(); err != nil {
+		p.logger.Warn("discovery republish failed", "err", err)
+	}
+}
+
+func (p *Publisher) getDeviceID() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.deviceID == "" {
+		return "device_id"
+	}
+	return p.deviceID
 }
 
 // Connect establishes the MQTT connection, retrying until successful or ctx is cancelled.
@@ -108,7 +139,7 @@ func (p *Publisher) Connect(ctx context.Context) error {
 // PublishDiscovery sends retained HA auto-discovery config messages for all sensors.
 func (p *Publisher) PublishDiscovery() error {
 	device := haDevice{
-		Identifiers:  []string{"device_id"},
+		Identifiers:  []string{p.getDeviceID()},
 		Name:         "Rainforest-EMU-2",
 		Manufacturer: "Rainforest Automation",
 		Model:        "EMU-2",

--- a/pkg/serial/serial.go
+++ b/pkg/serial/serial.go
@@ -19,6 +19,7 @@ import (
 // All numeric fields are hex strings (e.g. "0x000254").
 type instantaneousDemand struct {
 	XMLName     xml.Name `xml:"InstantaneousDemand"`
+	DeviceMacId string   `xml:"DeviceMacId"`
 	Demand      string   `xml:"Demand"`
 	Multiplier  string   `xml:"Multiplier"`
 	Divisor     string   `xml:"Divisor"`
@@ -29,6 +30,7 @@ type instantaneousDemand struct {
 // All numeric fields are hex strings.
 type currentSummationDelivered struct {
 	XMLName            xml.Name `xml:"CurrentSummationDelivered"`
+	DeviceMacId        string   `xml:"DeviceMacId"`
 	SummationDelivered string   `xml:"SummationDelivered"`
 	Multiplier         string   `xml:"Multiplier"`
 	Divisor            string   `xml:"Divisor"`
@@ -37,8 +39,9 @@ type currentSummationDelivered struct {
 
 // Metric is a parsed, computed reading ready for MQTT publication.
 type Metric struct {
-	SensorName string
-	Value      float64
+	SensorName  string
+	Value       float64
+	DeviceMacID string // raw hex from DeviceMacId field, e.g. "0xd8d5b9000000c28c"
 }
 
 // parseHex converts a "0x..."-prefixed hex string to int64.
@@ -89,7 +92,7 @@ func parseMessage(buf string) (*Metric, error) {
 		if err != nil {
 			return nil, fmt.Errorf("compute InstantaneousDemand: %w", err)
 		}
-		return &Metric{SensorName: "HomeCurrentDemand", Value: val}, nil
+		return &Metric{SensorName: "HomeCurrentDemand", Value: val, DeviceMacID: msg.DeviceMacId}, nil
 	}
 	if strings.Contains(buf, "<CurrentSummationDelivered>") {
 		var msg currentSummationDelivered
@@ -100,7 +103,7 @@ func parseMessage(buf string) (*Metric, error) {
 		if err != nil {
 			return nil, fmt.Errorf("compute CurrentSummationDelivered: %w", err)
 		}
-		return &Metric{SensorName: "HomeEnergyUsage", Value: val}, nil
+		return &Metric{SensorName: "HomeEnergyUsage", Value: val, DeviceMacID: msg.DeviceMacId}, nil
 	}
 	return nil, nil
 }
@@ -202,6 +205,8 @@ func (r *Reader) readLoop(ctx context.Context, port goserial.Port) {
 				case <-ctx.Done():
 					return
 				}
+			} else {
+				r.logger.Debug("unsupported message type", "raw", raw)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Replaces the Python/Poetry service with a single static Go binary
- Reads EMU-2 USB serial data, parses XML, and publishes to MQTT using Home Assistant auto-discovery
- Supports configuration via CLI flags (`-dev`, `-host`, `-user`, `-pass`, `-prefix`, `-debug`) with env var fallbacks
- Exponential-backoff reconnect on both serial port and MQTT broker
- Uses `DeviceMacId` from the EMU-2 messages as the HA device identifier (stable, unique, no config required)
- Multi-arch Docker image (`linux/amd64` + `linux/arm64`) published to GHCR on every merge to main
- Release binaries for `linux-amd64`, `darwin-amd64`, `darwin-arm64` attached to each GitHub release

## Structure

```
cmd/emu2mqtt/   entrypoint
pkg/config/     CLI flag + env var parsing
pkg/serial/     XML parsing, hex math, serial read loop
pkg/mqtt/       MQTT client, HA discovery, state publishing
```

## CI

- **ci.yaml** — `go test` + `golangci-lint` on PRs and pushes to main
- **release.yaml** — builds binaries, creates a dated GitHub release, pushes Docker image to GHCR

## Test plan

- [ ] CI passes (lint + tests)
- [ ] Binary connects to EMU-2 serial device and reads metrics
- [ ] MQTT discovery creates `Rainforest-EMU-2` device in Home Assistant with correct sensors
- [ ] Device identifier updates to real MAC on first metric received
- [ ] Docker image runs with `--device` flag and env var config

🤖 Generated with [Claude Code](https://claude.com/claude-code)